### PR TITLE
Remove unnecessary modules

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-asyncio
 aiohttp

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
   keywords = ['Riot API', 'python'],
   classifiers = [],
   install_requires=[
-    "asyncio",
     "aiohttp"
   ],
 )


### PR DESCRIPTION
pypi asyncio is only relevant for Python 3.3, which does not include asyncio in its stdlib.