### PR TITLE
Created tournament match endpoints

### DIFF
--- a/pantheon/pantheon.py
+++ b/pantheon/pantheon.py
@@ -374,8 +374,33 @@ class Pantheon():
         Returns the result of https://developer.riotgames.com/api-methods/#match-v4/GET_getMatchlist
         """
         return await self.fetch((self.BASE_URL_LOL + "match/v4/matchlists/by-account/{accountId}{params}").format(server=self._server, accountId=accountId, params = utils.urlParams(params)))
-    
-    
+
+
+    @errorHandler
+    @exceptions
+    @ratelimit
+    async def getMatchIdsByTournamentCode(self, tournamentCode):
+        """
+        :param int tournamentCode: tournamentCode from a game in a tournament
+        
+        Returns the result of https://developer.riotgames.com/api-methods/#match-v4/GET_getMatchIdsByTournamentCode
+        """
+        return await self.fetch((self.BASE_URL_LOL + "match/v4/matches/by-tournament-code/{tournamentCode}/ids").format(server=self._server, tournamentCode=tournamentCode))
+
+
+    @errorHandler
+    @exceptions
+    @ratelimit
+    async def getMatchByTournamentCode(self, matchId, tournamentCode):
+        """
+        :param int matchId: matchId of the match, also known as gameId
+        :param int tournamentCode: tournamentCode from a game in a tournament
+        
+        Returns the result of https://developer.riotgames.com/apis#match-v4/GET_getMatchByTournamentCode
+        """
+        return await self.fetch((self.BASE_URL_LOL + "match/v4/matches/{matchId}/by-tournament-code/{tournamentCode}").format(server=self._server, matchId=matchId, tournamentCode=tournamentCode))
+
+
     #Spectator
     @errorHandler
     @exceptions


### PR DESCRIPTION
Creates some tournament match endpoints such as getting a list of match ids from tournament code and getting a match from a tournament code.

Unfortunately I don't really see how we have a good way of testing this without creating our own non-stubbed tournament. Once I make my own tournament I will update these non-existent tests for these endpoints.