### PR TITLE
Fix issue with tournament api region bug

### DIFF
--- a/pantheon/pantheon.py
+++ b/pantheon/pantheon.py
@@ -19,7 +19,8 @@ class Pantheon():
     
     # PLATFORMS = ["br1","eun1","euw1","jp1","kr","la1","la2","na1","oc1","tr1","ru"]
     REGIONS = ["americas","asia","europe"]
-    TOURNAMENT_REGIONS = ["americas"]
+    TOURNAMENT_REGIONS = ["BR", "EUNE", "EUW", "JP", "LAN", "LAS", "NA", "OCE", "PBE", "RU", "TR"]
+
     
     
     def __init__(self, server, api_key, errorHandling = False, requestsLoggingFunction = None, debug=False):
@@ -492,12 +493,12 @@ class Pantheon():
     @ratelimit
     async def registerProvider(self, region, callback_url, stub=False):
         """
-        :param str region: region to get a provider for
+        :param str region: region to get a provider for, valid values are BR, EUNE, EUW, JP, LAN, LAS, NA, OCE, PBE, RU, TR
         :param str callback_url: url to which a callback will be sent after each match created with a tournament code from this provider
         
         Returns the result of https://developer.riotgames.com/api-methods/#tournament-stub-v4/POST_registerProviderData
         """
-        if self._server not in self.TOURNAMENT_REGIONS:
+        if region not in self.TOURNAMENT_REGIONS:
             raise exc.InvalidServer(self._server,self.TOURNAMENT_REGIONS)
         return await self.fetch((self.BASE_URL_LOL+"tournament{stub}/v4/providers").format(server=self._server, stub="-stub" if stub else ""), method="POST", data={"region":region, "url":callback_url})
     
@@ -512,8 +513,6 @@ class Pantheon():
         
         Returns the result of https://developer.riotgames.com/api-methods/#tournament-stub-v4/POST_registerTournament
         """
-        if self._server not in self.TOURNAMENT_REGIONS:
-            raise exc.InvalidServer(self._server,self.TOURNAMENT_REGIONS)
         return await self.fetch((self.BASE_URL_LOL+"tournament{stub}/v4/tournaments").format(server=self._server, stub="-stub" if stub else ""), method="POST", data={"providerId":providerId, "name":name})
     
     
@@ -534,8 +533,6 @@ class Pantheon():
         
         Returns the result of https://developer.riotgames.com/api-methods/#tournament-stub-v4/POST_createTournamentCode
         """
-        if self._server not in self.TOURNAMENT_REGIONS:
-            raise exc.InvalidServer(self._server,self.TOURNAMENT_REGIONS)
         return await self.fetch((self.BASE_URL_LOL+"tournament{stub}/v4/codes?count={nb_codes}&tournamentId={tournamentId}").format(server=self._server, stub="-stub" if stub else "", tournamentId=tournamentId, nb_codes=nb_codes), method="POST", data=data)
     
     

--- a/test/test_tournament.py
+++ b/test/test_tournament.py
@@ -3,7 +3,7 @@ from .config import *
 
 def test_providers():
     try:
-        data = loop.run_until_complete(panth_americas.registerProvider(tournament_region, tournament_url, stub))
+        data = loop.run_until_complete(panth.registerProvider(tournament_region, tournament_url, stub))
     except exc.Unauthorized as e:
         pytest.skip("API key unauthorized for tournament")
     except Exception as e:
@@ -13,8 +13,8 @@ def test_providers():
 
 def test_tournaments():
     try:
-        provider_id = loop.run_until_complete(panth_americas.registerProvider(tournament_region, tournament_url, stub))
-        data = loop.run_until_complete(panth_americas.registerTournament(provider_id, tournament_name, stub))
+        provider_id = loop.run_until_complete(panth.registerProvider(tournament_region, tournament_url, stub))
+        data = loop.run_until_complete(panth.registerTournament(provider_id, tournament_name, stub))
     except exc.Unauthorized as e:
         pytest.skip("API key unauthorized for tournament")
     except Exception as e:
@@ -32,9 +32,9 @@ def test_code():
         "teamSize": 5
     }
     try:
-        provider_id = loop.run_until_complete(panth_americas.registerProvider(tournament_region, tournament_url, stub))
-        tournament_id = loop.run_until_complete(panth_americas.registerTournament(provider_id, tournament_name, stub))
-        data = loop.run_until_complete(panth_americas.createTournamentCode(tournament_id, data_input, 1, stub))
+        provider_id = loop.run_until_complete(panth.registerProvider(tournament_region, tournament_url, stub))
+        tournament_id = loop.run_until_complete(panth.registerTournament(provider_id, tournament_name, stub))
+        data = loop.run_until_complete(panth.createTournamentCode(tournament_id, data_input, 1, stub))
     except exc.Unauthorized as e:
         pytest.skip("API key unauthorized for tournament")
     except Exception as e:
@@ -53,9 +53,9 @@ def test_multiple_codes():
         "teamSize": 5
     }
     try:
-        provider_id = loop.run_until_complete(panth_americas.registerProvider(tournament_region, tournament_url, stub))
-        tournament_id = loop.run_until_complete(panth_americas.registerTournament(provider_id, tournament_name, stub))
-        data = loop.run_until_complete(panth_americas.createTournamentCode(tournament_id, data_input, 5, stub))
+        provider_id = loop.run_until_complete(panth.registerProvider(tournament_region, tournament_url, stub))
+        tournament_id = loop.run_until_complete(panth.registerTournament(provider_id, tournament_name, stub))
+        data = loop.run_until_complete(panth.createTournamentCode(tournament_id, data_input, 5, stub))
     except exc.Unauthorized as e:
         pytest.skip("API key unauthorized for tournament")
     except Exception as e:
@@ -67,8 +67,8 @@ def test_multiple_codes():
     
 def test_lobby():
     try:
-        provider_id = loop.run_until_complete(panth_americas.registerProvider(tournament_region, tournament_url, stub))
-        data = loop.run_until_complete(panth_americas.getLobbyEvents(provider_id, stub))
+        provider_id = loop.run_until_complete(panth.registerProvider(tournament_region, tournament_url, stub))
+        data = loop.run_until_complete(panth.getLobbyEvents(provider_id, stub))
     except exc.Unauthorized as e:
         pytest.skip("API key unauthorized for tournament")
     except Exception as e:


### PR DESCRIPTION
Right now the tournament API doesn't work because it compares the server pantheon has (which will be one of `EUW1`, `NA1`, `...`) with the current value `self.TOURNAMENT_REGIONS` of `americas`.

This fixes this by only checking the region that is being passed in when calling `registerProvider` since that is one of the few places we can do validation, but removes it in `registerTournament` and `createTournamentCode` since those do not have any regions involved with it.

This also fixes some of the tournament tests by using the pantheon config to the normal one instead of americas.

I'm assuming that `americas` is the locale versioning used for other game APIs like TFT?